### PR TITLE
Update environment configs to adhere with new URLs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>no.ssb.guardian</groupId>
   <artifactId>guardian-client</artifactId>
-    <version>0.1.6-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <!-- Plugin/extension versions -->
     <artifactregistry-maven-wagon.version>2.2.3</artifactregistry-maven-wagon.version>
     <checkstyle.version>9.3</checkstyle.version>
-    <inject-maven-plugin.version>1.7</inject-maven-plugin.version>
+    <inject-maven-plugin.version>1.6</inject-maven-plugin.version>
     <jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
     <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
     <maven-checkstyle-plugin.version>3.5.0</maven-checkstyle-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -7,35 +7,35 @@
   <packaging>jar</packaging>
 
   <properties>
-    <java.version>11</java.version>
+    <java.version>17</java.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <artifact-registry.url>artifactregistry://europe-north1-maven.pkg.dev/artifact-registry-14da</artifact-registry.url>
 
     <!-- Dependency versions -->
-    <assertj.version>3.22.0</assertj.version>
+    <assertj.version>3.26.3</assertj.version>
     <caffeine.version>3.0.5</caffeine.version>
     <jackson.version>2.13.4.1</jackson.version>
     <jjwt.version>0.11.2</jjwt.version>
-    <junit.version>5.8.2</junit.version>
+    <junit.version>5.10.3</junit.version>
     <logback.version>1.2.10</logback.version>
-    <lombok.version>1.18.22</lombok.version>
-    <mockito.version>4.2.0</mockito.version>
-    <picocli.version>4.6.2</picocli.version>
+    <lombok.version>1.18.34</lombok.version>
+    <mockito.version>5.11.0</mockito.version>
+    <picocli.version>4.7.6</picocli.version>
     <slf4j.version>1.7.33</slf4j.version>
 
     <!-- Plugin/extension versions -->
-    <artifactregistry-maven-wagon.version>2.1.4</artifactregistry-maven-wagon.version>
+    <artifactregistry-maven-wagon.version>2.2.3</artifactregistry-maven-wagon.version>
     <checkstyle.version>9.3</checkstyle.version>
-    <inject-maven-plugin.version>1.3</inject-maven-plugin.version>
+    <inject-maven-plugin.version>1.7</inject-maven-plugin.version>
     <jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
-    <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
-    <maven-checkstyle-plugin.version>3.1.2</maven-checkstyle-plugin.version>
-    <maven-javadoc-plugin.version>3.3.0</maven-javadoc-plugin.version>
-    <maven-resources-plugin.version>3.2.0</maven-resources-plugin.version>
-    <maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
-    <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
-    <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
+    <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
+    <maven-checkstyle-plugin.version>3.5.0</maven-checkstyle-plugin.version>
+    <maven-javadoc-plugin.version>3.10.0</maven-javadoc-plugin.version>
+    <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
+    <maven-shade-plugin.version>3.6.0</maven-shade-plugin.version>
+    <maven-surefire-plugin.version>3.5.0</maven-surefire-plugin.version>
+    <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
     <moditect-maven-plugin.version>1.0.0.RC2</moditect-maven-plugin.version>
     <sonar-maven-plugin.version>3.9.1.2184</sonar-maven-plugin.version>
   </properties>
@@ -135,6 +135,9 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>${maven-compiler-plugin.version}</version>
         <configuration>
+          <source>${java.version}</source>
+          <target>${java.version}</target>
+          <release>${java.version}</release>
           <annotationProcessorPaths>
             <path>
               <groupId>org.projectlombok</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -212,30 +212,6 @@
           </execution>
         </executions>
       </plugin>
-<!--
-      <plugin>
-        <groupId>org.moditect</groupId>
-        <artifactId>moditect-maven-plugin</artifactId>
-        <version>${moditect-maven-plugin.version}</version>
-        <executions>
-          <execution>
-            <id>add-module-infos</id>
-            <phase>package</phase>
-            <goals>
-              <goal>add-module-info</goal>
-            </goals>
-            <configuration>
-              <overwriteExistingFiles>true</overwriteExistingFiles>
-              <module>
-                <moduleInfoFile>
-                  src/main/java/module-info.java
-                </moduleInfoFile>
-              </module>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
--->
       <plugin>
         <groupId>de.m3y.maven</groupId>
         <artifactId>inject-maven-plugin</artifactId>

--- a/src/main/java/no/ssb/guardian/client/GuardianClient.java
+++ b/src/main/java/no/ssb/guardian/client/GuardianClient.java
@@ -61,7 +61,7 @@ public class GuardianClient {
      * withConfig provides a fluent way to initialize a GuardianClient, like so:
      * <pre>
      *     GuardianClient.withConfig()
-     *     .environment(STAGING)
+     *     .environment(TEST)
      *     .maskinportenClientId("some-uuid")
      *     .keycloakClientSecret("some-secret")
      *     .create();

--- a/src/main/java/no/ssb/guardian/client/GuardianClientCli.java
+++ b/src/main/java/no/ssb/guardian/client/GuardianClientCli.java
@@ -1,5 +1,6 @@
 package no.ssb.guardian.client;
 
+import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
@@ -10,6 +11,7 @@ import java.util.Set;
 import static picocli.CommandLine.Help.Visibility.ALWAYS;
 
 @Slf4j
+@NoArgsConstructor
 @Command(name = "guardian",
         versionProvider = GuardianClientCli.class,
         description = "Retrieve access tokens from Maskinporten Guardian", mixinStandardHelpOptions = true)
@@ -34,6 +36,8 @@ public class GuardianClientCli implements Runnable, CommandLine.IVersionProvider
     @CommandLine.ArgGroup(exclusive = true, multiplicity = "1")
     Exclusive exclusive;
 
+    private GuardianClient client = null;
+
     static class Exclusive {
         @Option(names = {"-p", "--keycloak-client-secret"},
                 description = "Keycloak client secret (needed if Guardian client should fetch keycloak token)")
@@ -42,6 +46,10 @@ public class GuardianClientCli implements Runnable, CommandLine.IVersionProvider
         @Option(names = {"-t", "--keycloak-token"},
                 description = "Keycloak token")
         String staticKeycloakToken;
+    }
+
+    public GuardianClientCli(GuardianClient client) {
+        this.client = client;
     }
 
     @Override
@@ -58,33 +66,33 @@ public class GuardianClientCli implements Runnable, CommandLine.IVersionProvider
     }
 
     public void run() {
-        final GuardianClient client;
-
         if (verbose) {
             // Used by the CmdLogbackFilter to decide if verbose logs should be printed to stderr
             System.setProperty("GUARDIAN_CLIENT_VERBOSE", "true");
         }
 
-        // personal user
-        if (exclusive.staticKeycloakToken != null) {
-            client = new GuardianClient(GuardianClientConfig.builder()
-                    .environment(environment)
-                    .maskinportenClientId(maskinportenClientId)
-                    .staticKeycloakToken(exclusive.staticKeycloakToken)
-                    .build());
-        }
+        // Only create the client if it's not provided (i.e., production use)
+        if (this.client == null) {
+            // personal user
+            if (exclusive.staticKeycloakToken != null) {
+                client = new GuardianClient(GuardianClientConfig.builder()
+                        .environment(environment)
+                        .maskinportenClientId(maskinportenClientId)
+                        .staticKeycloakToken(exclusive.staticKeycloakToken)
+                        .build());
+            }
 
-        // service user
-        else {
-            client = new GuardianClient(GuardianClientConfig.builder()
-                    .environment(environment)
-                    .maskinportenClientId(maskinportenClientId)
-                    .keycloakClientSecret(exclusive.maskinportenClientSecret.toCharArray())
-                    .build());
+            // service user
+            else {
+                client = new GuardianClient(GuardianClientConfig.builder()
+                        .environment(environment)
+                        .maskinportenClientId(maskinportenClientId)
+                        .keycloakClientSecret(exclusive.maskinportenClientSecret.toCharArray())
+                        .build());
+            }
         }
 
         String token = client.getMaskinportenAccessToken(scopes);
-
 
         // Print token to stdout
         System.out.println(token);

--- a/src/main/java/no/ssb/guardian/client/GuardianClientCli.java
+++ b/src/main/java/no/ssb/guardian/client/GuardianClientCli.java
@@ -20,8 +20,8 @@ public class GuardianClientCli implements Runnable, CommandLine.IVersionProvider
     boolean verbose;
 
     @Option(names = {"-e", "--env"}, showDefaultValue = ALWAYS,
-            description = "Runtime environment (PROD, STAGING or LOCAL) the Guardian Client is working with")
-    GuardianClientConfig.Environment environment = GuardianClientConfig.Environment.STAGING;
+            description = "Runtime environment (PROD, TEST, LOCAL, STAGING_BIP or PROD_BIP) the Guardian Client is working with")
+    GuardianClientConfig.Environment environment = GuardianClientConfig.Environment.TEST;
 
     @Option(names = {"-u", "--maskinporten-client-id"},
             description = "Maskinporten client ID", required = true)

--- a/src/main/java/no/ssb/guardian/client/GuardianClientConfig.java
+++ b/src/main/java/no/ssb/guardian/client/GuardianClientConfig.java
@@ -57,7 +57,7 @@ public class GuardianClientConfig {
             return URI.create("https://guardian.dapla.ssb.no");
         }
         else if (environment == TEST) {
-            return URI.create("https://guardian.test.ssb.no");
+            return URI.create("https://guardian.dapla-staging.ssb.no");
         }
         else if (environment == PROD_BIP) {
             return URI.create("https://guardian.dapla.ssb.no");

--- a/src/main/java/no/ssb/guardian/client/Util.java
+++ b/src/main/java/no/ssb/guardian/client/Util.java
@@ -4,12 +4,19 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.jsonwebtoken.*;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Header;
+import io.jsonwebtoken.Jwt;
+import io.jsonwebtoken.JwtParser;
+import io.jsonwebtoken.Jwts;
 import lombok.experimental.UtilityClass;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.Base64;
+import java.util.Date;
+import java.util.Map;
+import java.util.Optional;
 
 @UtilityClass
 public class Util {

--- a/src/test/java/no/ssb/guardian/client/GuardianClientCliTest.java
+++ b/src/test/java/no/ssb/guardian/client/GuardianClientCliTest.java
@@ -1,0 +1,57 @@
+package no.ssb.guardian.client;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class GuardianClientCliTest {
+    private ByteArrayOutputStream outContent;
+    private GuardianClient mockGuardianClient;
+
+
+    final PrintStream originalOut = System.out;
+    final PrintStream originalErr = System.err;
+    final ByteArrayOutputStream out = new ByteArrayOutputStream();
+    final ByteArrayOutputStream err = new ByteArrayOutputStream();
+
+    @BeforeEach
+    public void setUpStreams() {
+        out.reset();
+        err.reset();
+        System.setOut(new PrintStream(out));
+        System.setErr(new PrintStream(err));
+        mockGuardianClient = mock(GuardianClient.class);
+    }
+
+    @AfterEach
+    public void restoreStreams() {
+        System.setOut(originalOut);
+        System.setErr(originalErr);
+    }
+
+    int executeClient(String[] args) {
+        return new CommandLine(new GuardianClientCli(mockGuardianClient)).execute(args);
+    }
+
+    @Test
+    void verboseOption_shouldSetSystemProperty() {
+        String[] args = {"-v", "-u", "maskinporten-client-id", "-p", "secret"};
+        executeClient(args);
+        assertThat(System.getProperty("GUARDIAN_CLIENT_VERBOSE")).isEqualTo("true");
+    }
+
+    @Test
+    void missingRequiredOption_shouldShowUsageMessage() throws Exception {
+        String[] args = {"-v"};
+        int exitCode = executeClient(args);
+        assertThat(exitCode).isNotEqualTo(0);
+        assertThat(err.toString()).contains("Usage: guardian");
+    }
+}

--- a/src/test/java/no/ssb/guardian/client/GuardianClientConfigTest.java
+++ b/src/test/java/no/ssb/guardian/client/GuardianClientConfigTest.java
@@ -2,7 +2,10 @@ package no.ssb.guardian.client;
 
 import org.junit.jupiter.api.Test;
 
+import java.net.URI;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class GuardianClientConfigTest {
     private static final String DUMMY_MASKINPORTEN_CLIENT_ID = "2fed8b0e-2d18-4eb9-81b2-fee27448518d";
@@ -84,4 +87,81 @@ class GuardianClientConfigTest {
         assertThat(config.getKeycloakTokenEndpoint()).isEqualTo ("/foo/bar");
     }
 
+    @Test
+    void guardianUrl_shouldThrowExceptionForMissingEnvironment() {
+        GuardianClientConfig config = GuardianClientConfig.builder()
+                .maskinportenClientId(DUMMY_MASKINPORTEN_CLIENT_ID)
+                .build();
+
+        assertThrows(IllegalStateException.class, config::getGuardianUrl);
+    }
+
+    @Test
+    void shortenedTokenExpirationInSeconds_shouldReturnDefaultIfNotProvided() {
+        GuardianClientConfig config = GuardianClientConfig.builder()
+                .maskinportenClientId(DUMMY_MASKINPORTEN_CLIENT_ID)
+                .build();
+
+        assertThat(config.getShortenedTokenExpirationInSeconds()).isEqualTo(300);
+    }
+
+    @Test
+    void keycloakTokenEndpoint_shouldReturnCustomEndpointIfProvided() {
+        String customEndpoint = "/custom/endpoint";
+        GuardianClientConfig config = GuardianClientConfig.builder()
+                .maskinportenClientId(DUMMY_MASKINPORTEN_CLIENT_ID)
+                .keycloakTokenEndpoint(customEndpoint)
+                .build();
+
+        assertThat(config.getKeycloakTokenEndpoint()).isEqualTo(customEndpoint);
+    }
+
+    @Test
+    void keycloakUrl_shouldReturnCustomUrlIfProvided() {
+        URI customUrl = URI.create("https://custom.keycloak.url");
+        GuardianClientConfig config = GuardianClientConfig.builder()
+                .maskinportenClientId(DUMMY_MASKINPORTEN_CLIENT_ID)
+                .keycloakUrl(customUrl)
+                .build();
+
+        assertThat(config.getKeycloakUrl()).isEqualTo(customUrl);
+    }
+
+    @Test
+    void guardianUrl_shouldReturnCustomUrlIfProvided() {
+        URI customUrl = URI.create("https://custom.guardian.url");
+        GuardianClientConfig config = GuardianClientConfig.builder()
+                .maskinportenClientId(DUMMY_MASKINPORTEN_CLIENT_ID)
+                .guardianUrl(customUrl)
+                .build();
+
+        assertThat(config.getGuardianUrl()).isEqualTo(customUrl);
+    }
+
+    @Test
+    void getGuardianUrl_local_returnsCorrectUrl() {
+        GuardianClientConfig config = GuardianClientConfig.builder()
+                .maskinportenClientId(DUMMY_MASKINPORTEN_CLIENT_ID)
+                .environment(GuardianClientConfig.Environment.LOCAL)
+                .build();
+        assertThat(config.getGuardianUrl()).hasToString("http://localhost:10310");
+    }
+
+    @Test
+    void getGuardianUrl_prodBip_returnsCorrectUrl() {
+        GuardianClientConfig config = GuardianClientConfig.builder()
+                .maskinportenClientId(DUMMY_MASKINPORTEN_CLIENT_ID)
+                .environment(GuardianClientConfig.Environment.PROD_BIP)
+                .build();
+        assertThat(config.getGuardianUrl()).hasToString("https://guardian.dapla.ssb.no");
+    }
+
+    @Test
+    void getGuardianUrl_stagingBip_returnsCorrectUrl() {
+        GuardianClientConfig config = GuardianClientConfig.builder()
+                .maskinportenClientId(DUMMY_MASKINPORTEN_CLIENT_ID)
+                .environment(GuardianClientConfig.Environment.STAGING_BIP)
+                .build();
+        assertThat(config.getGuardianUrl()).hasToString("https://guardian.dapla-staging.ssb.no");
+    }
 }

--- a/src/test/java/no/ssb/guardian/client/GuardianClientConfigTest.java
+++ b/src/test/java/no/ssb/guardian/client/GuardianClientConfigTest.java
@@ -8,10 +8,10 @@ class GuardianClientConfigTest {
     private static final String DUMMY_MASKINPORTEN_CLIENT_ID = "2fed8b0e-2d18-4eb9-81b2-fee27448518d";
 
     @Test
-    void deduceGuardianUrl_staging_shouldUseExternalUrl() {
+    void deduceGuardianUrl_test_shouldUseExternalUrl() {
         GuardianClientConfig config = GuardianClientConfig.builder()
                 .maskinportenClientId(DUMMY_MASKINPORTEN_CLIENT_ID)
-                .environment(GuardianClientConfig.Environment.STAGING)
+                .environment(GuardianClientConfig.Environment.TEST)
                 .build();
 
         assertThat(config.getGuardianUrl()).hasToString("https://guardian.dapla-staging.ssb.no");
@@ -21,11 +21,67 @@ class GuardianClientConfigTest {
     void deduceGuardianUrl_internalAccess_shouldUseInternalUrl() {
         GuardianClientConfig config = GuardianClientConfig.builder()
                 .maskinportenClientId(DUMMY_MASKINPORTEN_CLIENT_ID)
-                .environment(GuardianClientConfig.Environment.STAGING)
+                .environment(GuardianClientConfig.Environment.TEST)
                 .internalAccess(true)
                 .build();
 
         assertThat(config.getGuardianUrl()).hasToString("http://maskinporten-guardian.dapla.svc.cluster.local");
+    }
+
+    @Test
+    void deduceKeycloakUrl_test_shouldUseTestKeycloakUrl() {
+        GuardianClientConfig config = GuardianClientConfig.builder()
+                .maskinportenClientId(DUMMY_MASKINPORTEN_CLIENT_ID)
+                .environment(GuardianClientConfig.Environment.TEST)
+                .build();
+
+        assertThat(config.getKeycloakUrl()).hasToString("https://auth.test.ssb.no");
+        assertThat(config.getKeycloakTokenEndpoint()).isEqualTo ("/realms/ssb/protocol/openid-connect/token");
+    }
+
+    @Test
+    void deduceKeycloakUrl_prod_shouldUseTestKeycloakUrl() {
+        GuardianClientConfig config = GuardianClientConfig.builder()
+                .maskinportenClientId(DUMMY_MASKINPORTEN_CLIENT_ID)
+                .environment(GuardianClientConfig.Environment.PROD)
+                .build();
+
+        assertThat(config.getKeycloakUrl()).hasToString("https://auth.ssb.no");
+        assertThat(config.getKeycloakTokenEndpoint()).isEqualTo ("/realms/ssb/protocol/openid-connect/token");
+    }
+
+    @Test
+    void deduceKeycloakUrl_bipStaging_shouldUseLegacyKeycloakUrl() {
+        GuardianClientConfig config = GuardianClientConfig.builder()
+                .maskinportenClientId(DUMMY_MASKINPORTEN_CLIENT_ID)
+                .environment(GuardianClientConfig.Environment.STAGING_BIP)
+                .build();
+
+        assertThat(config.getKeycloakUrl()).hasToString("https://keycloak.staging-bip-app.ssb.no");
+        assertThat(config.getKeycloakTokenEndpoint()).isEqualTo ("/auth/realms/ssb/protocol/openid-connect/token");
+    }
+
+    @Test
+    void deduceKeycloakUrl_bipProd_shouldUseLegacyKeycloakUrl() {
+        GuardianClientConfig config = GuardianClientConfig.builder()
+                .maskinportenClientId(DUMMY_MASKINPORTEN_CLIENT_ID)
+                .environment(GuardianClientConfig.Environment.PROD_BIP)
+                .build();
+
+        assertThat(config.getKeycloakUrl()).hasToString("https://keycloak.prod-bip-app.ssb.no");
+        assertThat(config.getKeycloakTokenEndpoint()).isEqualTo ("/auth/realms/ssb/protocol/openid-connect/token");
+    }
+
+    @Test
+    void deduceKeycloakUrl_bipProdWithCustomEndpoint_shouldUseCustomEndpoint() {
+        GuardianClientConfig config = GuardianClientConfig.builder()
+                .maskinportenClientId(DUMMY_MASKINPORTEN_CLIENT_ID)
+                .environment(GuardianClientConfig.Environment.PROD_BIP)
+                .keycloakTokenEndpoint("/foo/bar")
+                .build();
+
+        assertThat(config.getKeycloakUrl()).hasToString("https://keycloak.prod-bip-app.ssb.no");
+        assertThat(config.getKeycloakTokenEndpoint()).isEqualTo ("/foo/bar");
     }
 
 }

--- a/src/test/java/no/ssb/guardian/client/GuardianClientTest.java
+++ b/src/test/java/no/ssb/guardian/client/GuardianClientTest.java
@@ -4,13 +4,12 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;
-import java.security.Guard;
 import java.time.Instant;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.UUID;
 
-import static no.ssb.guardian.client.GuardianClientConfig.Environment.STAGING;
+import static no.ssb.guardian.client.GuardianClientConfig.Environment.TEST;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -45,7 +44,7 @@ class GuardianClientTest {
         assertThat(requiredEnv("TEST_KEYCLOAK_CLIENT_SECRET")).isNotBlank();
 
         GuardianClient client = new GuardianClient(GuardianClientConfig.builder()
-                .environment(STAGING)
+                .environment(TEST)
                 .maskinportenClientId(requiredEnv("TEST_MASKINPORTEN_CLIENT_ID"))
                 .keycloakClientSecret(requiredEnv("TEST_KEYCLOAK_CLIENT_SECRET").toCharArray())
                 .build());
@@ -64,7 +63,7 @@ class GuardianClientTest {
         assertThat(requiredEnv("TEST_KEYCLOAK_TOKEN")).isNotBlank();
 
         GuardianClient client = new GuardianClient(GuardianClientConfig.builder()
-                .environment(STAGING)
+                .environment(TEST)
                 .maskinportenClientId(requiredEnv("TEST_MASKINPORTEN_CLIENT_ID"))
                 .staticKeycloakToken(requiredEnv("TEST_KEYCLOAK_TOKEN"))
                 .build());

--- a/src/test/java/no/ssb/guardian/client/UtilTest.java
+++ b/src/test/java/no/ssb/guardian/client/UtilTest.java
@@ -1,10 +1,15 @@
 package no.ssb.guardian.client;
 
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
 import org.junit.jupiter.api.Test;
 
 import java.util.Base64;
+import java.util.Date;
+import java.util.Map;
+import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 class UtilTest {
 
@@ -16,6 +21,70 @@ class UtilTest {
         String decoded = new String(Base64.getDecoder().decode(b64Encoded));
         assertTrue(decoded.startsWith(clientId));
         assertTrue(decoded.endsWith(clientSecret));
+    }
+
+
+    @Test
+    void jsonToMap_shouldConvertJsonToMap() {
+        String json = "{\"key\":\"value\"}";
+        Map<String, Object> map = Util.jsonToMap(json);
+        assertEquals("value", map.get("key"));
+    }
+
+    @Test
+    void jsonToMap_shouldThrowExceptionForInvalidJson() {
+        String invalidJson = "{key:value}";
+        assertThrows(GuardianClientException.class, () -> Util.jsonToMap(invalidJson));
+    }
+
+    @Test
+    void toJson_shouldConvertObjectToJson() {
+        Map<String, String> map = Map.of("key", "value");
+        String json = Util.toJson(map);
+        assertTrue(json.contains("\"key\":\"value\""));
+    }
+
+    @Test
+    void toJson_shouldThrowExceptionForInvalidObject() {
+        Object invalidObject = new Object() {
+            @Override
+            public String toString() {
+                throw new RuntimeException("Invalid object");
+            }
+        };
+        assertThrows(GuardianClientException.class, () -> Util.toJson(invalidObject));
+    }
+
+    @Test
+    void jwtClaimsOf_shouldReturnClaims() {
+        String jwtString = Jwts.builder().setSubject("user").compact();
+        Claims claims = Util.jwtClaimsOf(jwtString);
+        assertEquals("user", claims.getSubject());
+    }
+
+    @Test
+    void jwtClaimsOf_shouldThrowExceptionForInvalidJwt() {
+        String invalidJwt = "invalid.jwt.token";
+        assertThrows(GuardianClientException.class, () -> Util.jwtClaimsOf(invalidJwt));
+    }
+
+    @Test
+    void jwtExpirationDateOf_shouldReturnExpirationDate() {
+        Date expiration = new Date(System.currentTimeMillis() + 10000);
+        String jwtString = Jwts.builder().setExpiration(expiration).compact();
+        Date result = Util.jwtExpirationDateOf(jwtString);
+
+        assertEquals(expiration.getTime() / 1000, result.getTime() / 1000);
+    }
+
+    @Test
+    void jwtClaimOf_shouldReturnClaimIfExists() {
+        String jwtString = Jwts.builder()
+                .claim("key", "value")
+                .compact();
+        Optional<Object> claim = Util.jwtClaimOf(jwtString, "key");
+        assertTrue(claim.isPresent());
+        assertEquals("value", claim.get());
     }
 
 }

--- a/src/test/java/no/ssb/guardian/client/UtilTest.java
+++ b/src/test/java/no/ssb/guardian/client/UtilTest.java
@@ -1,6 +1,5 @@
 package no.ssb.guardian.client;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Base64;


### PR DESCRIPTION
Moving from BIP, we now have new URLs for Keycloak.

This PR renames the environment definitions `PROD` to `PROD_BIP` and `STAGING` to `STAGING_BIP`. The environment variables `PROD`, `TEST` and `LOCAL` now points to new Keycloak URLs:
* PROD: https://auth.ssb.no
* TEST:  https://auth.test.ssb.no
* LOCAL:  https://auth-play.test.ssb.no

BREAKING CHANGE: If bumping to new version of guardian-client-java, you must also update your environment config if you are deducing URLs from environment. If you have been using `PROD` or `STAGING`, you should replace these with `PROD_BIP` or `STAGING_BIP`. Alternatively, you should use `PROD` and `TEST` and make sure that  Maskinporten M2M clients exists in the new Keycloak instance.
