### PR TITLE
Update guardian urls

### DIFF
--- a/src/main/java/no/ssb/guardian/client/DefaultMaskinportenTokenResolver.java
+++ b/src/main/java/no/ssb/guardian/client/DefaultMaskinportenTokenResolver.java
@@ -7,6 +7,7 @@ import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
+import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
@@ -32,8 +33,9 @@ public class DefaultMaskinportenTokenResolver implements MaskinportenTokenResolv
         log.debug(VERBOSE, "getMaskinportenAccessToken (user type: {})", isServiceUser ? "service" : "personal");
 
         String requestBody = Util.toJson(getAccessTokenRequestBody(isServiceUser(keycloakToken), scopes));
+        URI url = config.getGuardianUrl().resolve("/maskinporten/access-token");
         HttpRequest request = HttpRequest.newBuilder()
-                .uri(config.getGuardianUrl().resolve("/maskinporten/access-token"))
+                .uri(url)
                 .header("User-Agent", GuardianClient.userAgent())
                 .header("Content-Type", "application/json")
                 .header("Authorization", "Bearer " + keycloakToken)
@@ -52,15 +54,17 @@ public class DefaultMaskinportenTokenResolver implements MaskinportenTokenResolv
             log.trace("keycloakToken", keycloakToken);
             log.trace("requestBody", requestBody);
             throw new GuardianClientException(String.format(
-                    "Error fetching maskinporten access token for client id %s",
+                    "Error fetching maskinporten access token from %s for client id %s",
+                    url,
                     config.getMaskinportenClientId()
             ), e);
         }
 
         if (response.statusCode() != 200) {
             throw new GuardianClientException(String.format(
-                    "Error (%s) fetching maskinporten access token for client id %s: %s",
+                    "Error (%s) fetching maskinporten access token from %s for client id %s: %s",
                     response.statusCode(),
+                    url,
                     config.getMaskinportenClientId(),
                     response.body()
             ));

--- a/src/main/java/no/ssb/guardian/client/GuardianClient.java
+++ b/src/main/java/no/ssb/guardian/client/GuardianClient.java
@@ -38,7 +38,7 @@ public class GuardianClient {
                    @NonNull MaskinportenTokenResolver maskinportenTokenResolver) {
         this.config = config;
         this.keycloakTokenResolver = keycloakTokenResolver;
-        this.maskinportenTokenResolver =maskinportenTokenResolver;
+        this.maskinportenTokenResolver = maskinportenTokenResolver;
         this.cache = Caffeine.newBuilder()
                 .expireAfter(new Expiry<String, AccessTokenWrapper>() {
                     @Override
@@ -55,6 +55,7 @@ public class GuardianClient {
                     }
                 })
                 .build();
+        log.debug("GuardianClient initialized with config: {}", config.toDebugString());
     }
 
     /**

--- a/src/main/java/no/ssb/guardian/client/GuardianClientConfig.java
+++ b/src/main/java/no/ssb/guardian/client/GuardianClientConfig.java
@@ -206,4 +206,31 @@ public class GuardianClientConfig {
         PROD, TEST, LOCAL, PROD_BIP, STAGING_BIP
     }
 
+    public String toDebugString() {
+        return String.format("""
+            {
+              maskinportenClientId = '%s',
+              environment = %s,
+              internalAccess = %b,
+              guardianUrl = %s,
+              keycloakUrl = %s,
+              keycloakTokenEndpoint = '%s',
+              keycloakClientId = '%s',
+              shortenedTokenExpirationInSeconds = %d,
+              keycloakClientSecret = '%s',
+              staticKeycloakToken = '%s'
+            }
+            """,
+                maskinportenClientId,
+                environment,
+                internalAccess,
+                getGuardianUrl(),
+                getKeycloakUrl(),
+                getKeycloakTokenEndpoint(),
+                getKeycloakClientId(),
+                shortenedTokenExpirationInSeconds,
+                keycloakClientSecret != null ? "****" : "null",
+                staticKeycloakToken != null ? "****" : "null"
+        );
+    }
 }

--- a/src/main/java/no/ssb/guardian/client/GuardianClientConfig.java
+++ b/src/main/java/no/ssb/guardian/client/GuardianClientConfig.java
@@ -54,10 +54,10 @@ public class GuardianClientConfig {
             return URI.create("http://maskinporten-guardian.dapla.svc.cluster.local");
         }
         else if (environment == PROD) {
-            return URI.create("https://guardian.dapla.ssb.no");
+            return URI.create("https://guardian.intern.ssb.no");
         }
         else if (environment == TEST) {
-            return URI.create("https://guardian.dapla-staging.ssb.no");
+            return URI.create("https://guardian.intern.test.ssb.no");
         }
         else if (environment == PROD_BIP) {
             return URI.create("https://guardian.dapla.ssb.no");

--- a/src/test/java/no/ssb/guardian/client/GuardianClientConfigTest.java
+++ b/src/test/java/no/ssb/guardian/client/GuardianClientConfigTest.java
@@ -17,7 +17,7 @@ class GuardianClientConfigTest {
                 .environment(GuardianClientConfig.Environment.TEST)
                 .build();
 
-        assertThat(config.getGuardianUrl()).hasToString("https://guardian.dapla-staging.ssb.no");
+        assertThat(config.getGuardianUrl()).hasToString("https://guardian.intern.test.ssb.no");
     }
 
     @Test
@@ -86,6 +86,19 @@ class GuardianClientConfigTest {
         assertThat(config.getKeycloakUrl()).hasToString("https://keycloak.prod-bip-app.ssb.no");
         assertThat(config.getKeycloakTokenEndpoint()).isEqualTo ("/foo/bar");
     }
+
+    @Test
+    void deduceKeycloakUrl_naisProdWithCustomEndpoint_shouldUseCustomEndpoint() {
+        GuardianClientConfig config = GuardianClientConfig.builder()
+                .maskinportenClientId(DUMMY_MASKINPORTEN_CLIENT_ID)
+                .environment(GuardianClientConfig.Environment.PROD)
+                .keycloakTokenEndpoint("/foo/bar")
+                .build();
+
+        assertThat(config.getKeycloakUrl()).hasToString("https://auth.ssb.no");
+        assertThat(config.getKeycloakTokenEndpoint()).isEqualTo ("/foo/bar");
+    }
+
 
     @Test
     void guardianUrl_shouldThrowExceptionForMissingEnvironment() {
@@ -163,5 +176,19 @@ class GuardianClientConfigTest {
                 .environment(GuardianClientConfig.Environment.STAGING_BIP)
                 .build();
         assertThat(config.getGuardianUrl()).hasToString("https://guardian.dapla-staging.ssb.no");
+    }
+
+    @Test
+    void toDebugString_shouldReturnMaskedSecrets() {
+        GuardianClientConfig config = GuardianClientConfig.builder()
+                .maskinportenClientId(DUMMY_MASKINPORTEN_CLIENT_ID)
+                .keycloakClientSecret("my-secret".toCharArray())
+                .staticKeycloakToken("my-token")
+                .environment(GuardianClientConfig.Environment.TEST)
+                .build();
+        System.out.println(config.toDebugString());
+
+        assertThat(config.toDebugString()).contains("keycloakClientSecret = '****'");
+        assertThat(config.toDebugString()).contains("staticKeycloakToken = '****'");
     }
 }


### PR DESCRIPTION
Default to using `guardian.intern.ssb.no` (PROD) and `guardian.intern.test.ssb.no` (TEST) when relying on `guardian.environment` to deduce guardian urls

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/statisticsnorway/guardian-client-java/19)
<!-- Reviewable:end -->
